### PR TITLE
Fixes for OpenAI - tranlsation result and info if no source value

### DIFF
--- a/client/src/js/App.vue
+++ b/client/src/js/App.vue
@@ -271,4 +271,12 @@ export default {
     }
   }
 }
+
+.level51-autotranslateNoSourceValue {
+  color: red;
+
+  .font-icon-translatable {
+    color: red;
+  }
+}
 </style>

--- a/client/src/js/App.vue
+++ b/client/src/js/App.vue
@@ -184,7 +184,8 @@ export default {
         const blacklist = this.payload.termsBlacklist || '';
         let requestContent = 'Translate the following text from ' +  this.sourceLocale.code + ' to ' + this.targetLocale.code;
         if(blacklist) requestContent += ', but do not translate the words from this list: ' + blacklist;
-        requestContent += '. Here is the value to translate: ' + this.sourceValue;
+        requestContent += ' Only give me the translation as a result.';
+        requestContent += '. Here is the value to translate: ' + this.sourceValue + '';
 
         const stream = await client.chat.completions.create({
           model: 'gpt-4o-mini',

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -3,5 +3,5 @@ de:
     Translation: 'Automatische Übersetzung'
     BlackListValues: 'Blacklist Werte'
     BlackListValuesDescription: 'Geben Sie einen Wert pro Zeile ein. Der Übersetzer ignoriert diese Werte und behält sie unverändert bei.'
-  Level51\FluentAutotranslate\AutotranslateField:
+  Level51\Autotranslate\AutotranslateField:
     NO_SOURCE_VALUE: 'Kein Ausgangswert'

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -3,3 +3,5 @@ de:
     Translation: 'Automatische Übersetzung'
     BlackListValues: 'Blacklist Werte'
     BlackListValuesDescription: 'Geben Sie einen Wert pro Zeile ein. Der Übersetzer ignoriert diese Werte und behält sie unverändert bei.'
+  Level51\FluentAutotranslate\AutotranslateField:
+    NO_SOURCE_VALUE: 'Kein Ausgangswert'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -3,3 +3,5 @@ en:
     Translation: 'Auto Translate'
     BlackListValues: 'Blacklist Values'
     BlackListValuesDescription: 'Enter one value per line, the translator will ignore these values and keep them as they are.'
+  Level51\FluentAutotranslate\AutotranslateField:
+    NO_SOURCE_VALUE: 'No source value'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -3,5 +3,5 @@ en:
     Translation: 'Auto Translate'
     BlackListValues: 'Blacklist Values'
     BlackListValuesDescription: 'Enter one value per line, the translator will ignore these values and keep them as they are.'
-  Level51\FluentAutotranslate\AutotranslateField:
+  Level51\Autotranslate\AutotranslateField:
     NO_SOURCE_VALUE: 'No source value'

--- a/src/AutotranslateFieldExtension.php
+++ b/src/AutotranslateFieldExtension.php
@@ -262,6 +262,15 @@ class AutotranslateFieldExtension extends Extension
         return $this->sourceValue;
     }
 
+    public function hasAutotranslateSourceValue()
+    {
+        $locale = Locale::getCurrentLocale();
+        if ($locale->getIsDefault()) {
+            return true; // always return true for default locale
+        }
+        return $this->getAutotranslateSourceValue() !== null;
+    }
+
     /**
      * Get the active translation provider.
      *

--- a/templates/Level51/Autotranslate/FormField_holder.ss
+++ b/templates/Level51/Autotranslate/FormField_holder.ss
@@ -9,7 +9,7 @@
 
         <% if $isAutotranslateActionAvailable %>
             <div id="$AutotranslateFieldID" class="level51-autotranslateFieldPlaceholder" data-payload='$AutotranslateFieldPayload.RAW'></div>
-        <% else_if not $getAutotranslateSourceValue %>
+        <% else_if not $hasAutotranslateSourceValue %>
             <div class="level51-autotranslateNoSourceValue">
                 <i class="font-icon font-icon-translatable"></i>
                 <%t Level51\Autotranslate\AutotranslateField.NO_SOURCE_VALUE 'No source value' %>

--- a/templates/Level51/Autotranslate/FormField_holder.ss
+++ b/templates/Level51/Autotranslate/FormField_holder.ss
@@ -9,6 +9,11 @@
 
         <% if $isAutotranslateActionAvailable %>
             <div id="$AutotranslateFieldID" class="level51-autotranslateFieldPlaceholder" data-payload='$AutotranslateFieldPayload.RAW'></div>
+        <% else_if not $getAutotranslateSourceValue %>
+            <div class="level51-autotranslateNoSourceValue">
+                <i class="font-icon font-icon-translatable"></i>
+                <%t Level51\FluentAutotranslate\AutotranslateField.NO_SOURCE_VALUE 'No source value' %>
+            </div>
         <% end_if %>
     </div>
     <% if $RightTitle %><p class="form__field-extra-label" id="extra-label-$ID">$RightTitle</p><% end_if %>

--- a/templates/Level51/Autotranslate/FormField_holder.ss
+++ b/templates/Level51/Autotranslate/FormField_holder.ss
@@ -12,7 +12,7 @@
         <% else_if not $getAutotranslateSourceValue %>
             <div class="level51-autotranslateNoSourceValue">
                 <i class="font-icon font-icon-translatable"></i>
-                <%t Level51\FluentAutotranslate\AutotranslateField.NO_SOURCE_VALUE 'No source value' %>
+                <%t Level51\Autotranslate\AutotranslateField.NO_SOURCE_VALUE 'No source value' %>
             </div>
         <% end_if %>
     </div>


### PR DESCRIPTION
- Fixed Open AI request for translation (we sometimes received something like this: _The translation of ‘Design Thinking’ from German to English is ‘Design Thinking’_, so we updated the query phrase).
- Added an info text when there is no source value, there was a little confusion when there is no translation option for the field but the field is basically translatable